### PR TITLE
Name flag required in UpdateKeyCmd

### DIFF
--- a/cmd/okms/keys/keys.go
+++ b/cmd/okms/keys/keys.go
@@ -394,6 +394,9 @@ func newUpdateKeyCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Update key with a new name")
+	if err := cmd.MarkFlagRequired("name"); err != nil {
+		panic(err)
+	}
 
 	return cmd
 }


### PR DESCRIPTION
The swagger require a name parameter of `length >= 1.  
I enforce the name parameter to fail fast and avoid sending a request with empty name. 