### PR TITLE
fix(kmip): skip unset extractable and sensitive attributes flags.

### DIFF
--- a/cmd/okms/kmip/create.go
+++ b/cmd/okms/kmip/create.go
@@ -51,9 +51,13 @@ func createSymmetricKey() *cobra.Command {
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		req := kmipClient.Create().
-			SymmetricKey(kmip.CryptographicAlgorithm(alg), *size, usage.ToCryptographicUsageMask()).
-			WithAttribute(kmip.AttributeNameExtractable, *extractable).
-			WithAttribute(kmip.AttributeNameSensitive, *sensitive)
+			SymmetricKey(kmip.CryptographicAlgorithm(alg), *size, usage.ToCryptographicUsageMask())
+		if cmd.Flags().Changed("extractable") {
+			req = req.WithAttribute(kmip.AttributeNameExtractable, *extractable)
+		}
+		if cmd.Flags().Changed("sensitive") {
+			req = req.WithAttribute(kmip.AttributeNameSensitive, *sensitive)
+		}
 		if *name != "" {
 			req = req.WithName(*name)
 		}
@@ -127,9 +131,13 @@ func createKeyPair() *cobra.Command {
 		if *publicName != "" {
 			req = req.PublicKey().WithName(*publicName)
 		}
-		req = req.PrivateKey().
-			WithAttribute(kmip.AttributeNameExtractable, *privateExtractable).
-			WithAttribute(kmip.AttributeNameSensitive, *privateSensitive)
+		req = req.PrivateKey()
+		if cmd.Flags().Changed("private-extractable") {
+			req = req.WithAttribute(kmip.AttributeNameExtractable, *privateExtractable)
+		}
+		if cmd.Flags().Changed("private-sensitive") {
+			req = req.WithAttribute(kmip.AttributeNameSensitive, *privateSensitive)
+		}
 		if *description != "" {
 			req = req.Common().WithAttribute(kmip.AttributeNameDescription, *description)
 		}

--- a/cmd/okms/kmip/register.go
+++ b/cmd/okms/kmip/register.go
@@ -112,9 +112,13 @@ VALUE can be either plain text, a '-' to read from stdin, or a filename prefixed
 		}
 
 		req := kmipClient.Register().
-			SymmetricKey(kmip.CryptographicAlgorithm(alg), usage.ToCryptographicUsageMask(), key).
-			WithAttribute(kmip.AttributeNameExtractable, *extractable).
-			WithAttribute(kmip.AttributeNameSensitive, *sensitive)
+			SymmetricKey(kmip.CryptographicAlgorithm(alg), usage.ToCryptographicUsageMask(), key)
+		if cmd.Flags().Changed("extractable") {
+			req = req.WithAttribute(kmip.AttributeNameExtractable, *extractable)
+		}
+		if cmd.Flags().Changed("sensitive") {
+			req = req.WithAttribute(kmip.AttributeNameSensitive, *sensitive)
+		}
 		if *name != "" {
 			req = req.WithName(*name)
 		}
@@ -275,9 +279,13 @@ VALUE can be either plain text, a '-' to read from stdin, or a filename prefixed
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		key := flagsmgmt.BytesFromArg(args[0], 16_000)
 
-		req := kmipClient.Register().PemPrivateKey(key, usage.ToCryptographicUsageMask()).
-			WithAttribute(kmip.AttributeNameExtractable, *extractable).
-			WithAttribute(kmip.AttributeNameSensitive, *sensitive)
+		req := kmipClient.Register().PemPrivateKey(key, usage.ToCryptographicUsageMask())
+		if cmd.Flags().Changed("extractable") {
+			req = req.WithAttribute(kmip.AttributeNameExtractable, *extractable)
+		}
+		if cmd.Flags().Changed("sensitive") {
+			req = req.WithAttribute(kmip.AttributeNameSensitive, *sensitive)
+		}
 		if *name != "" {
 			req = req.WithName(*name)
 		}


### PR DESCRIPTION
When not set, values will be set by server's. Flags explicitely needs to be set to false when needed.

This is needed for pykmip compatibility which does not support the "extractable" attribute