### PR TITLE
feat(configure): change HTTP to RESTAPI in configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ version: 1
 profile: default # Name of the active profile
 profiles:
   default:
-    http:
+    restapi:
       endpoint: https://myserver.acme.com
       ca: /path/to/public-ca.crt # Optional if the CA is in system store
       auth:
@@ -128,10 +128,10 @@ profiles:
 
 These settings can be overwritten using environment variables:
 
-- KMS_HTTP_ENDPOINT
-- KMS_HTTP_CA
-- KMS_HTTP_CERT
-- KMS_HTTP_KEY
+- KMS_RESTAPI_ENDPOINT
+- KMS_RESTAPI_CA
+- KMS_RESTAPI_CERT
+- KMS_RESTAPI_KEY
 and
 - KMS_KMIP_ENDPOINT
 - KMS_KMIP_CA
@@ -140,10 +140,10 @@ and
 
 ```bash
 # REST API
-export KMS_HTTP_ENDPOINT=https://myserver.acme.com
-export KMS_HTTP_CA=/path/to/certs/ca.crt
-export KMS_HTTP_CERT=/path/to/certs/user.crt
-export KMS_HTTP_KEY=/path/to/certs/user.key
+export KMS_RESTAPI_ENDPOINT=https://myserver.acme.com
+export KMS_RESTAPI_CA=/path/to/certs/ca.crt
+export KMS_RESTAPI_CERT=/path/to/certs/user.crt
+export KMS_RESTAPI_KEY=/path/to/certs/user.key
 
 # KMIP
 export KMS_KMIP_ENDPOINT=myserver.acme.com:5696

--- a/cmd/okms/common/client.go
+++ b/cmd/okms/common/client.go
@@ -35,7 +35,7 @@ func SetupRestApiFlags(command *cobra.Command, cust CustomizeFunc) {
 		f = cust(command)
 	}
 
-	config.SetupEndpointFlags(command, "http", func(command *cobra.Command, cfg config.EndpointConfig) {
+	config.SetupEndpointFlags(command, "restapi", func(command *cobra.Command, cfg config.EndpointConfig) {
 		okmsId = cfg.Auth.GetOkmsId()
 		clientCfg := okms.ClientConfig{
 			Timeout: timeout,

--- a/cmd/okms/configure/root.go
+++ b/cmd/okms/configure/root.go
@@ -42,21 +42,21 @@ func CreateCommand() *cobra.Command {
 }
 
 func Run(profile string) {
-	choice := exit.OnErr2(pterm.DefaultInteractiveSelect.WithOptions([]string{"HTTP", "KMIP"}).Show("Select a protocol to configure"))
+	choice := exit.OnErr2(pterm.DefaultInteractiveSelect.WithOptions([]string{"REST-API", "KMIP"}).Show("Select a protocol to configure"))
 	switch choice {
-	case "HTTP":
-		config.ReadUserInput("Endpoint", "http.endpoint", profile, config.ValidateURL)
-		config.ReadUserInput("CA file", "http.ca", profile, config.ValidateFileExists.AllowEmpty())
+	case "REST-API":
+		config.ReadUserInput("Endpoint", "restapi.endpoint", profile, config.ValidateURL)
+		config.ReadUserInput("CA file", "restapi.ca", profile, config.ValidateFileExists.AllowEmpty())
 		authChoice := exit.OnErr2(pterm.DefaultInteractiveSelect.WithOptions([]string{"mtls", "token"}).Show("Select authentication to configure"))
 		switch authChoice {
 		case "mtls":
-			config.SetConfigKey(profile, "http.auth.type", "mtls")
-			config.ReadUserInput("Certificate file", "http.auth.cert", profile, config.ValidateFileExists)
-			config.ReadUserInput("Private key file", "http.auth.key", profile, config.ValidateFileExists)
+			config.SetConfigKey(profile, "restapi.auth.type", "mtls")
+			config.ReadUserInput("Certificate file", "restapi.auth.cert", profile, config.ValidateFileExists)
+			config.ReadUserInput("Private key file", "restapi.auth.key", profile, config.ValidateFileExists)
 		case "token":
-			config.SetConfigKey(profile, "http.auth.type", "token")
-			config.ReadUserInput("Token", "http.auth.token", profile, config.ValidateNotEmpty)
-			config.ReadUserInput("okmsId", "http.auth.okmsId", profile, config.ValidateUUID)
+			config.SetConfigKey(profile, "restapi.auth.type", "token")
+			config.ReadUserInput("Token", "restapi.auth.token", profile, config.ValidateNotEmpty)
+			config.ReadUserInput("okmsId", "restapi.auth.okmsId", profile, config.ValidateUUID)
 		}
 	case "KMIP":
 		config.ReadUserInput("CA file", "kmip.ca", profile, config.ValidateFileExists.AllowEmpty())

--- a/cmd/okms/okms.sample.yaml
+++ b/cmd/okms/okms.sample.yaml
@@ -2,7 +2,7 @@ version: 1
 profile: default # Name of the active profile
 profiles:
   default:
-    http:
+    restapi:
       endpoint: https://myserver.acme.com
       ca: /path/to/public-ca.crt # Optional if the CA is in system store
       auth:
@@ -17,7 +17,7 @@ profiles:
         cert: /path/to/domain/cert.pem
         key: /path/to/domain/key.pem
   my-profile:
-    http:
+    restapi:
       endpoint: https://my-profile.kms.ovh:8080
       ca: /path/to/public-ca.crt
       auth:

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -140,21 +140,45 @@ func loadV1(command *cobra.Command, service string) EndpointConfig {
 	}
 
 	envPrefix := "KMS_" + strings.ToUpper(service)
-	k := k.Cut(fmt.Sprintf("profiles.%s.%s", profile, service))
+	profilePrefix := fmt.Sprintf("profiles.%s.", profile)
 
-	ep := GetString(k, "endpoint", envPrefix+"_ENDPOINT", command.Flags().Lookup("endpoint"))
+	// For the "restapi" service, transparently fall back to the legacy "http"
+	// section when the new key is absent, so that existing config files and
+	// KMS_HTTP_* environment variables continue to work unchanged.
+	svcKey := k.Cut(profilePrefix + service)
+	if service == "restapi" && !k.Exists(profilePrefix+service) {
+		if k.Exists(profilePrefix + "http") {
+			svcKey = k.Cut(profilePrefix + "http")
+		}
+		// Always allow KMS_HTTP_* as a fallback for KMS_RESTAPI_*.
+		envPrefix = resolveEnvPrefix("KMS_RESTAPI", "KMS_HTTP")
+	}
+
+	ep := GetString(svcKey, "endpoint", envPrefix+"_ENDPOINT", command.Flags().Lookup("endpoint"))
 	if ep == "" {
 		exit.OnErr(errors.New("Missing endpoint address parameter"))
 	}
-	caFile := GetString(k, "ca", envPrefix+"_CA", command.Flags().Lookup("ca"))
+	caFile := GetString(svcKey, "ca", envPrefix+"_CA", command.Flags().Lookup("ca"))
 
-	authMethod := GetString(k, "auth.type", envPrefix+"_AUTH_METHOD", command.Flags().Lookup("auth-method"))
+	authMethod := GetString(svcKey, "auth.type", envPrefix+"_AUTH_METHOD", command.Flags().Lookup("auth-method"))
 
 	return EndpointConfig{
 		Endpoint: ep,
 		CaFile:   exit.OnErr2(utils.ExpandTilde(caFile)),
-		Auth:     buildAuthMethod(service, authMethod, command, k.Cut("auth"), envPrefix),
+		Auth:     buildAuthMethod(service, authMethod, command, svcKey.Cut("auth"), envPrefix),
 	}
+}
+
+// resolveEnvPrefix returns primary if any environment variable with that prefix
+// is set, otherwise it returns fallback. This allows KMS_HTTP_* variables to
+// act as a transparent alias for KMS_RESTAPI_* variables.
+func resolveEnvPrefix(primary, fallback string) string {
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, primary+"_") {
+			return primary
+		}
+	}
+	return fallback
 }
 
 func GetString(k *koanf.Koanf, key, env string, flag *pflag.Flag) string {
@@ -232,7 +256,7 @@ func migrateV0toV1(k *koanf.Koanf) *koanf.Koanf {
 		prefix := "profiles." + key + "."
 		pk := k.Cut(key)
 
-		migrateServiceConfigV0toV1(pk, nk, prefix+"http.")
+		migrateServiceConfigV0toV1(pk, nk, prefix+"restapi.")
 
 		for _, svc := range pk.MapKeys("") {
 			pk := pk.Cut(svc)

--- a/common/config/flags.go
+++ b/common/config/flags.go
@@ -12,7 +12,7 @@ import (
 func SetupEndpointFlags(command *cobra.Command, service string, init func(cmd *cobra.Command, cfg EndpointConfig)) {
 	service = strings.ToLower(service)
 	desc := "KMS endpoint URL"
-	if service != "" && service != "http" {
+	if service != "" && service != "http" && service != "restapi" {
 		desc = fmt.Sprintf("Endpoint address to %s", service)
 	}
 	command.PersistentFlags().String("endpoint", "", desc)


### PR DESCRIPTION
REST-API is mentionned in OVHcloud Manager, but not HTTP. Change for coherence. 
`http` is kept in the configuration file for backward compatibility. 

Should fix #231 